### PR TITLE
digest/sha1 is missing from required modules

### DIFF
--- a/lib/json-schema-generator.rb
+++ b/lib/json-schema-generator.rb
@@ -1,4 +1,5 @@
+require 'digest/sha1'
+require 'stringio'
 require 'json'
 require 'json/schema_generator'
 require 'json/schema_generator_cli'
-require 'stringio'


### PR DESCRIPTION
when running from command line I used to get following error:

```
morozgrafix$ json-schema-generator test.json --schema-version draft3
/Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/gems/json-schema-generator-0.0.8/lib/json/schema_generator.rb:41:in `generate': uninitialized constant JSON::SchemaGenerator::Digest (NameError)
    from /Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/gems/json-schema-generator-0.0.8/lib/json/schema_generator.rb:14:in `generate'
    from /Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/gems/json-schema-generator-0.0.8/lib/json/schema_generator_cli.rb:31:in `execute!'
    from /Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/gems/json-schema-generator-0.0.8/bin/json-schema-generator:5:in `<top (required)>'
    from /Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/bin/json-schema-generator:23:in `load'
    from /Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/bin/json-schema-generator:23:in `<main>'
    from /Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/morozgrafix/.rvm/gems/ruby-2.0.0-p0/bin/ruby_noexec_wrapper:14:in `<main>'
```

I had to add to json-schema-generator.rb

```
require 'digest/sha1'
```

In order to get shasum calculated correctly on line 41 of schema_generator.rb

Not sure if this is something to do with my local environment, but I figured it may help someone else if they run into this problem.
