### PR TITLE
Added an allow_null option which adds the 'null' type to all properties in the schema

### DIFF
--- a/lib/json/schema_generator.rb
+++ b/lib/json/schema_generator.rb
@@ -27,6 +27,7 @@ module JSON
       end
 
       @defaults = opts[:defaults]
+      @allow_null = opts[:allow_null]
 
       @buffer = StringIO.new
       @name = name
@@ -72,7 +73,11 @@ module JSON
         raise "Unknown Primitive Type for #{key}! #{value.class}"
       end
 
-      statement_group.add "\"type\": \"#{type}\""
+      if @allow_null
+        statement_group.add "\"type\": #{[type, "null"]}"
+      else
+        statement_group.add "\"type\": \"#{type}\""
+      end
       statement_group.add "\"required\": #{required}" if @version == DRAFT3
       statement_group.add "\"default\": #{value.inspect}" if @defaults
     end

--- a/lib/json/schema_generator_cli.rb
+++ b/lib/json/schema_generator_cli.rb
@@ -24,6 +24,7 @@ class JSON::SchemaGeneratorCLI
         "Version of json-schema to generate (#{supported_versions.join ', '}).  Default: #{default_version}") do |schema_version|
           options[:schema_version] = schema_version
         end
+      opts.on("--allow-null", "Includes 'null' as an allow type for all properties in the schema") { options[:allow_null] = true }
       opts.parse!
     end
 


### PR DESCRIPTION
Added an allow_null option which adds the 'null' type to all properties in the schema. This is useful when you need the schema to allow null values in the JSON being validated.

This is a bit of a hack so I understand if you don't want to merge the changes. We've just picked up Pacto today and this null values issue is blocking us. Happy to hear your feedback if you have any suggestions.
