### PR TITLE
Relax restrictions for Arrays

### DIFF
--- a/lib/json/schema_generator/brute_force_required_search.rb
+++ b/lib/json/schema_generator/brute_force_required_search.rb
@@ -5,19 +5,11 @@ module JSON
     class BruteForceRequiredSearch
       def initialize(data)
         @data = data.dup
-        if data.is_a? Array
-          @json_path = ['$[*]']
-        else
-          @json_path = ['$']
-        end
+        @json_path = data.is_a?(Array) ? ['$[*]'] : ['$']
       end
 
       def push(key, value)
-        if value.is_a? Array
-          @json_path.push "#{key}[*]"
-        else
-          @json_path.push key
-        end
+        @json_path.push value.is_a?(Array) ? "#{key}[*]" : key
       end
 
       def pop
@@ -42,16 +34,12 @@ module JSON
         end
       end
 
-      def child_keys 
+      def child_keys
         JsonPath.new(current_path).on(@data).map(&:keys).flatten.uniq
       end
 
       def find_required
-        required = []
-        child_keys.each do |child_key|
-          required << child_key if required? child_key
-        end
-        required
+        child_keys.select {|k| required? k}
       end
     end
   end


### PR DESCRIPTION
Existing implementation makes assumptions that all items in an array will match the schema of the first item in the array. Absent a more complicated means of parsing all arrays, reducing requirements for arrays seems warranted. This implementation only works for draft-4, and while it can be refactored to also support draft-3, this works for my needs and I just wanted to share the code in case you want to use some of it, or someone else finds it useful.
