### PR TITLE
To fix the array of hash with different key in each postion of the array

### DIFF
--- a/lib/json/schema_generator.rb
+++ b/lib/json/schema_generator.rb
@@ -1,6 +1,5 @@
 require 'json/schema_generator/statement_group'
 require 'json/schema_generator/brute_force_required_search'
-
 module JSON
   class SchemaGenerator
     DRAFT3 = 'draft-03'
@@ -72,7 +71,7 @@ module JSON
         raise "Unknown Primitive Type for #{key}! #{value.class}"
       end
 
-      statement_group.add "\"type\": \"#{type}\""
+      statement_group.add "\"oneOf\": [{\"type\": \"#{type}\"}, {\"type\": \"null\"}]"
       statement_group.add "\"required\": #{required}" if @version == DRAFT3
       statement_group.add "\"default\": #{value.inspect}" if @defaults
     end
@@ -128,8 +127,11 @@ module JSON
         statement_group.add '"minItems": 1'
       end
       statement_group.add '"uniqueItems": true'
-      statement_group.add create_values("items", data.first, required_keys, true)
-
+      if data.first.is_a? Hash
+       statement_group.add create_values("items", data.inject(:merge),required_keys, true)
+      else
+       statement_group.add create_values("items", data.first, required_keys, true)
+      end
       statement_group
     end
 


### PR DESCRIPTION
When a hash have 2 different key in an array of hash
`  [{:updated_at=>"2021-03-04T14:09:39Z"}, {:created_at=>"2021-03-04T14:09:39Z"}]
`
The json-schema before the fix
   `{
"$schema": "http://json-schema.org/draft-04/schema#", "description": "Generated from api/schema_validator/temp_central/ticket_schema.json with shasum 1c8f30491c9f48b5d44942b7ca0f04e60d8af2a6", "type": "array", "minItems": 1, "uniqueItems": true, "items": {
"type": "object", "properties": {
"updated_at": {
"oneOf": [{"type": "string"}, {"type": "null"}]
}
}
}
}
`

After the fix 
`{
"$schema": "http://json-schema.org/draft-04/schema#", "description": "Generated from api/schema_validator/temp_central/ticket_schema.json with shasum 1c8f30491c9f48b5d44942b7ca0f04e60d8af2a6", "type": "array", "minItems": 1, "uniqueItems": true, "items": {
"type": "object", "properties": {
"updated_at": {
"oneOf": [{"type": "string"}, {"type": "null"}]
}
, "created_at": {
"oneOf": [{"type": "string"}, {"type": "null"}]
}
}
}
}
`

It should consider both the key in different position of the hash